### PR TITLE
Performance Improvements

### DIFF
--- a/Source/CoupledMixingMatrix.cpp
+++ b/Source/CoupledMixingMatrix.cpp
@@ -133,15 +133,15 @@ void CoupledMixingMatrix::preComputeFilterVariables(){
     }
 }
 
-Eigen::VectorXcf CoupledMixingMatrix::process(Eigen::VectorXcf delayLineOutput){   
+void CoupledMixingMatrix::process(){
     if (!isFilter)
-        delayLineInput = (M_block.cwiseProduct(couplingScalars)) * delayLineOutput;
+        delayLineInput = (M_block.cwiseProduct(couplingScalars)) * filterOutput;
     
     else{
         
         //update previous filter inputs
         prevDelayLineOutput = prevDelayLineOutput * perm;
-        prevDelayLineOutput.col(0) = delayLineOutput;
+        prevDelayLineOutput.col(0) = filterOutput;
         
         //filter with polynomial FIR matrix
         filterOutput.setZero();
@@ -163,6 +163,4 @@ Eigen::VectorXcf CoupledMixingMatrix::process(Eigen::VectorXcf delayLineOutput){
         delayLineInput = filterOutput;
        
     }
-   
-    return delayLineInput;
 }

--- a/Source/CoupledMixingMatrix.cpp
+++ b/Source/CoupledMixingMatrix.cpp
@@ -14,46 +14,33 @@ CoupledMixingMatrix::CoupledMixingMatrix(){};
 
 
 CoupledMixingMatrix::~CoupledMixingMatrix(){
-    delete [] PolyMat;
     delete [] coeffs;
 };
 
 void CoupledMixingMatrix::initialize(int nGrp, int totalDel, int *nDel){
     
+    jassert(totalDel == nDelayLines);
+
     nGroup = nGrp;
-    nDelayLines = totalDel;
     nSize = nDel;
     isFilter = true;
     
-    M_block.resize(nDelayLines, nDelayLines);
     M_block.setIdentity();
     couplingCoeff = 0.0f;
     
     if (!isFilter){
-        couplingScalars.resize(nDelayLines, nDelayLines);
         couplingScalars.setIdentity();
     }
-    
     else{
-        
         I.real(0); I.imag(1.0);
-        PolyMat = new Eigen::MatrixXcf [firOrder+1];
         coeffs = new std::complex<float> [firOrder+1];
-        prevDelayLineOutput.resize(nDelayLines, firOrder+1);
         prevDelayLineOutput.setZero();
         
         perm.resize(firOrder+1);
         perm.indices() = {2,0,1};
-        
    
         for(int i = 0; i < firOrder+1; i++){
-            PolyMat[i].resize(nDelayLines, nDelayLines);
             PolyMat[i].setZero();
-        }
-
-        M_Block_time_PolyMat.resize(firOrder + 1);
-        for(int i = 0; i < firOrder+1; i++){
-            M_Block_time_PolyMat[i].resize(nDelayLines, nDelayLines);
         }
 
 //        couplingFilters = new FIRFilter*[nDelayLines];
@@ -64,9 +51,6 @@ void CoupledMixingMatrix::initialize(int nGrp, int totalDel, int *nDel){
 //
 //        }
     }
-    
-    delayLineInput.resize(nDelayLines);
-    filterOutput.resize(nDelayLines);
 }
 
 

--- a/Source/CoupledMixingMatrix.h
+++ b/Source/CoupledMixingMatrix.h
@@ -32,18 +32,20 @@ public:
     void preComputeFilterVariables();
 
 private:
-    Eigen::MatrixXf M_block;
-    Eigen::MatrixXf couplingScalars;
+    static constexpr int nDelayLines = 16; // total number of delay lines
+    static constexpr int firOrder = 2;     //polynomial matrix order
+    using cf = std::complex<float>;
+    
+    Eigen::Matrix<cf, nDelayLines, nDelayLines> M_block;
+    Eigen::Matrix<cf, nDelayLines, nDelayLines> couplingScalars;
     Eigen::Matrix2f couplingMatrix2D;
     
-    const int firOrder = 2;     //polynomial matrix order
-    Eigen::MatrixXcf* PolyMat;          //Filter matrix represented as polynomials
-    Eigen::MatrixXcf prevDelayLineOutput;   //to store previous delay line outputs for filtering
+    std::array<Eigen::Matrix<cf, nDelayLines, nDelayLines>, firOrder + 1> PolyMat; //Filter matrix represented as polynomials
+    Eigen::Matrix<cf, nDelayLines, firOrder + 1> prevDelayLineOutput;   //to store previous delay line outputs for filtering
     Eigen::PermutationMatrix<3,3> perm;     //shift columns of storage matrix to the right
     //FIRFilter** couplingFilters;    //2D array of coupling Filters
     
-    
-    int nGroup, nDelayLines;
+    int nGroup;
     int *nSize;
     bool isFilter;
     float couplingCoeff;
@@ -53,9 +55,9 @@ private:
     std::complex<float>* coeffs;
     
     // intermediate filter calculations
-    std::vector<Eigen::MatrixXcf> M_Block_time_PolyMat;
+    std::array<Eigen::Matrix<cf, nDelayLines, nDelayLines>, firOrder + 1> M_Block_time_PolyMat;
 
     // temporaries for process()
-    Eigen::VectorXcf delayLineInput;
-    Eigen::VectorXcf filterOutput;
+    Eigen::Matrix<cf, nDelayLines, 1> delayLineInput;
+    Eigen::Matrix<cf, nDelayLines, 1> filterOutput;
 };

--- a/Source/CoupledMixingMatrix.h
+++ b/Source/CoupledMixingMatrix.h
@@ -29,6 +29,8 @@ public:
     void updateCouplingFilters();
     Eigen::VectorXcf process(Eigen::VectorXcf delayLineOutput);
     
+    void preComputeFilterVariables();
+
 private:
     Eigen::MatrixXf M_block;
     Eigen::MatrixXf couplingScalars;
@@ -50,5 +52,10 @@ private:
     std::complex<float> I;  //square root of negative 1
     std::complex<float>* coeffs;
     
-    
+    // intermediate filter calculations
+    std::vector<Eigen::MatrixXcf> M_Block_time_PolyMat;
+
+    // temporaries for process()
+    Eigen::VectorXcf delayLineInput;
+    Eigen::VectorXcf filterOutput;
 };

--- a/Source/CoupledMixingMatrix.h
+++ b/Source/CoupledMixingMatrix.h
@@ -18,6 +18,10 @@
 
 
 class CoupledMixingMatrix{
+    static constexpr int nDelayLines = 16; // total number of delay lines
+    static constexpr int firOrder = 2;     //polynomial matrix order
+    using cf = std::complex<float>;
+
 public:
     CoupledMixingMatrix();
     ~CoupledMixingMatrix();
@@ -27,15 +31,16 @@ public:
     void updateCouplingCoeff(float alpha);
     void updateBeta(float beta);
     void updateCouplingFilters();
-    Eigen::VectorXcf process(Eigen::VectorXcf delayLineOutput);
+
+    using DelayLinesIO = Eigen::Matrix<cf, nDelayLines, 1>;
+    DelayLinesIO* getDelayLineInput() { return &delayLineInput; }
+    DelayLinesIO* getDelayLineOutput() { return &filterOutput; }
+
+    void process();
     
     void preComputeFilterVariables();
 
 private:
-    static constexpr int nDelayLines = 16; // total number of delay lines
-    static constexpr int firOrder = 2;     //polynomial matrix order
-    using cf = std::complex<float>;
-    
     Eigen::Matrix<cf, nDelayLines, nDelayLines> M_block;
     Eigen::Matrix<cf, nDelayLines, nDelayLines> couplingScalars;
     Eigen::Matrix2f couplingMatrix2D;
@@ -58,6 +63,6 @@ private:
     std::array<Eigen::Matrix<cf, nDelayLines, nDelayLines>, firOrder + 1> M_Block_time_PolyMat;
 
     // temporaries for process()
-    Eigen::Matrix<cf, nDelayLines, 1> delayLineInput;
-    Eigen::Matrix<cf, nDelayLines, 1> filterOutput;
+    DelayLinesIO delayLineInput;
+    DelayLinesIO filterOutput;
 };

--- a/Source/DelayLine.cpp
+++ b/Source/DelayLine.cpp
@@ -29,25 +29,3 @@ void DelayLine::prepare(const int L, const float sampleRate){
 void DelayLine::setFilterCoefficients(float gDC, float gPI, float fT){
     T60Filter.updateCoeff(gDC, gPI, fT);
 }
-
-
-std::complex<float> DelayLine::read(){
-    return T60Filter.process(delayBuffer[readPtr]);
-}
-
-void DelayLine::write(const std::complex<float> input){
-  
-    delayBuffer[writePtr] = input;
-}
-
-//I referenced Jatin's FDN DelayUtils.h to update the DelayLine read and write pointers
-void DelayLine::update(){
-    --writePtr;
-    
-    if (writePtr < 0) // wrap write pointer
-        writePtr = maxDelay - 1;
-    
-    readPtr = writePtr + length;
-    if (readPtr >= maxDelay) // wrap read pointer
-        readPtr -= maxDelay;
-}

--- a/Source/DelayLine.h
+++ b/Source/DelayLine.h
@@ -19,9 +19,29 @@ public:
     
     void setFilterCoefficients(float gDC, float gPI, float fT);     //T60 filter at end of delayline
     void prepare(const int L, const float sampleRate);    //function to set delay line length
-    std::complex<float> read();        //read from pointer
-    void write(const std::complex<float> input);      //write a pointer
-    void update();      //update Pointers
+
+    //read from pointer
+    inline std::complex<float> read() const noexcept {
+        return delayBuffer[readPtr];
+    }
+
+    //write a pointer
+    inline void write(const std::complex<float> input) {
+
+        delayBuffer[writePtr] = T60Filter.process(input);
+    }
+
+    //update Pointers: I referenced Jatin's FDN DelayUtils.h to update the DelayLine read and write pointers
+    inline void update() {
+        --writePtr;
+
+        if (writePtr < 0) // wrap write pointer
+            writePtr = maxDelay - 1;
+
+        readPtr = writePtr + length;
+        if (readPtr >= maxDelay) // wrap read pointer
+            readPtr -= maxDelay;
+    }
     
 private:
     enum

--- a/Source/GFDN.cpp
+++ b/Source/GFDN.cpp
@@ -38,10 +38,8 @@ void GFDN::initialize(int nGrp, float sR, int* nDel, int* LR, int* UR, int numCh
     M_block.resize(totalDelayLines, totalDelayLines);
     couplingMatrix.initialize(nGroups, totalDelayLines, nDelayLines);
     
-    delayLineOutput.resize(totalDelayLines);
-    delayLineOutput.setZero();
-    delayLineInput.resize(totalDelayLines);
-    delayLineInput.setZero();
+    delayLineOutput = couplingMatrix.getDelayLineOutput();
+    delayLineInput = couplingMatrix.getDelayLineInput();
     
     //initialize driver and receiver coefficients
     b = new float[totalDelayLines];
@@ -183,9 +181,9 @@ float* GFDN::processSample(float input[], int numChannels){
         //loop through all delay lines in groups
          for(int k = 0; k < nDelayLines[i]; k++){
              fdns[i].buffers[k].update();
-             fdns[i].buffers[k].write(b[j]*input[chan] + delayLineInput(j));
-             delayLineOutput(j) = fdns[i].buffers[k].read();
-             output[chan] += c[j] * std::real(delayLineOutput(j));
+             fdns[i].buffers[k].write(b[j]*input[chan] + delayLineInput->operator()(j));
+             delayLineOutput->operator()(j) = fdns[i].buffers[k].read();
+             output[chan] += c[j] * std::real(delayLineOutput->operator()(j));
              j++;
          }
         
@@ -195,7 +193,7 @@ float* GFDN::processSample(float input[], int numChannels){
         output[chan] += dryMix * input[chan];    }
 
     
-    delayLineInput = couplingMatrix.process(delayLineOutput);
+    couplingMatrix.process();
     //std::cout << "Input : " << input << ", Output : " <<  output << std::endl;
     return output.data();
 

--- a/Source/GFDN.h
+++ b/Source/GFDN.h
@@ -47,11 +47,6 @@ private:
 
     std::vector<float> output;
     Eigen::MatrixXf M_block;
-    Eigen::VectorXcf delayLineOutput;
-    Eigen::VectorXcf delayLineInput;
-    
-    
-
-    
-    
+    CoupledMixingMatrix::DelayLinesIO* delayLineOutput = nullptr;
+    CoupledMixingMatrix::DelayLinesIO* delayLineInput = nullptr;
 };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -210,6 +210,32 @@ void Gfdn_pluginAudioProcessor::prepareToPlay (double sampleRate, int samplesPer
     inputData = std::vector<std::vector<float>>(samplesPerBlock, std::vector<float>(numChannels, 0.0f));
     prevSourcePos = 0;
     prevListenerPos = 0;
+
+    // simple benchmark to look at performance...
+#if 0
+    AudioBuffer<float> impulseBuffer(2, samplesPerBlock);
+    impulseBuffer.setSample(0, 0, 1.0f);
+    impulseBuffer.setSample(1, 0, 1.0f);
+
+    MidiBuffer midi;
+
+    int hundredSecondsInSamples = int(100.0 * sampleRate);
+
+    auto start = Time::getMillisecondCounterHiRes();
+    for (int i = 0; i < hundredSecondsInSamples; i += samplesPerBlock)
+    {
+        processBlock(impulseBuffer, midi);
+        impulseBuffer.clear();
+    }
+
+    auto duration = (Time::getMillisecondCounterHiRes() - start) / 1000.0;
+
+    Logger::writeToLog("Processed 100 seconds of audio in " + String(duration) + " seconds");
+    Logger::writeToLog("Realtime factor: " + String(100.0 / duration) + "x");
+
+    jassertfalse;
+    duration = 0.0;
+#endif
 }
 
 void Gfdn_pluginAudioProcessor::releaseResources()

--- a/Source/ShelfFilter.cpp
+++ b/Source/ShelfFilter.cpp
@@ -68,17 +68,3 @@ float* ShelfFilter::getDenominatorCoefficients(){
     
     return denCoeff;
 }
-
-//process each sample
-std::complex<float> ShelfFilter::process(const std::complex<float> input){
-    std::complex<float> output = b0*input + b1*prevInput - a1*prevOutput;
-    prevInput = input;
-    prevOutput = output;
-    
-    return output;
-}
-
-
-
-
-

--- a/Source/ShelfFilter.h
+++ b/Source/ShelfFilter.h
@@ -23,7 +23,15 @@ public:
     void updateCoeff(float g_dc, float g_pi, float fT);
     float* getNumeratorCoefficients();
     float* getDenominatorCoefficients();
-    std::complex<float> process(const std::complex<float> input);
+    
+    //process each sample
+    inline std::complex<float> process(const std::complex<float> input) {
+        std::complex<float> output = b0 * input + b1 * prevInput - a1 * prevOutput;
+        prevInput = input;
+        prevOutput = output;
+
+        return output;
+    }
     
     
 private:


### PR DESCRIPTION
Optimizations include:
- pre-computing `M_block.cwiseProduct(PolyMat[i])` in `CoupledMixingMatrix::process()`
- Switching `CoupledMixingMatrix` to use matrices with sizes determined at compile-time, for real-time critical operations
- Inilining methods in `DelayLine` and `ShelfFilter` that were being called many times per sample
- Adjusting the way that data gets in and out of `CoupledMixingMatrix::process()`

I also added a little bit of code that can be used as a very rough performance benchmark, in `PluginProcessor::prepareToPlay()`. The code is disabled with a `#if 0` by default, but can be enabled for making performance measurements.